### PR TITLE
[rec] Added YouTube API into relevance based score recommendation

### DIFF
--- a/project_start/express-api/routes/post.js
+++ b/project_start/express-api/routes/post.js
@@ -102,6 +102,7 @@ router.post("/new-post", async (req, res, next) => {
       mood,
       rating,
       audioFeatures,
+      youtubeStatistics,
     } = req.body;
     const Posts = Parse.Object.extend("Posts");
     const post = new Posts();
@@ -144,7 +145,9 @@ router.post("/new-post", async (req, res, next) => {
         avgRating: parseInt(rating),
         quantity: 1,
         genres: response.data.genres,
-        score: 0,
+        score:
+          parseInt(rating) * Math.log(2) +
+          Math.log(youtubeStatistics.viewCount) / Math.log(100),
         dance: audioFeatures.danceability,
         energy: audioFeatures.energy,
         speech: audioFeatures.speechiness,
@@ -152,6 +155,7 @@ router.post("/new-post", async (req, res, next) => {
         instru: audioFeatures.instrumentalness,
         live: audioFeatures.liveness,
         vale: audioFeatures.valence,
+        youtubeStatistics: youtubeStatistics,
       });
 
       await song.save();
@@ -170,7 +174,8 @@ router.post("/new-post", async (req, res, next) => {
         "score",
         currSong.get("avgRating") * Math.log(currSong.get("quantity") + 1) +
           currSong.get("likes").length / 50 +
-          currSong.get("comments").length / 50
+          currSong.get("comments").length / 50 +
+          Math.log(currSong.get(youtubeStatistics).viewCount) / Math.log(100)
       );
       await currSong.save();
       res.status(200).json(currSong);

--- a/project_start/express-api/routes/youtube.js
+++ b/project_start/express-api/routes/youtube.js
@@ -1,7 +1,6 @@
+const express = require("express");
 const router = express.Router();
 
-const { query } = require("express");
-const { isLocalDatastoreEnabled } = require("parse/lib/node/Parse.js");
 const Parse = require("parse/node");
 const ParseKeys = require("../parseKeys.js");
 Parse.initialize(ParseKeys[0], ParseKeys[1]);
@@ -11,19 +10,33 @@ const youtube = require("../youtubeSetup.js");
 
 router.get("/search-list", async (req, res, next) => {
   const result = await youtube.search.list({
-    q: query,
+    q: req.body.query,
     part: ["id"],
     type: ["video"],
     maxResults: 1,
   });
-  res.status(200).json(result);
+  const videoId = result.data.items[0].id.videoId;
+  console.log(videoId);
+  const getIdResults = await youtube.videos.list({
+    id: videoId,
+    part: ["statistics"],
+    maxResults: 1,
+  });
+
+  const youtubeStatistics = getIdResults.data.items[0].statistics;
+
+  res.status(200).json(youtubeStatistics);
 });
 
-router.get("/id", async (req, res, next) => {
-  const result = await youtube.videos.list({
-    id: isLocalDatastoreEnabled,
-    part: ["snippet", "contentDetails", "statistics"],
-    maxResults: 0,
-  });
-  return result;
-});
+// router.get("/id", async (req, res, next) => {
+//   console.log("reached inside!!!!!");
+//   console.log(req.body.id);
+//   const result = await youtube.videos.list({
+//     id: [req.body.id],
+//     part: ["snippet", "contentDetails", "statistics"],
+//     maxResults: 1,
+//   });
+//   res.status(200).json(result);
+// });
+
+module.exports = router;

--- a/project_start/express-api/server.js
+++ b/project_start/express-api/server.js
@@ -25,6 +25,7 @@ const Post = require("./routes/post.js");
 const Recommendations = require("./routes/recommendations.js");
 const Statistics = require("./routes/statistics.js");
 const Profile = require("./routes/profile.js");
+const YouTube = require("./routes/youtube.js");
 
 const Parse = require("parse/node");
 
@@ -192,6 +193,7 @@ app.use("/post", Post);
 app.use("/recommendations", Recommendations);
 app.use("/statistics", Statistics);
 app.use("/profile", Profile);
+app.use("/youtube", YouTube);
 
 // Initialize Login table and check if user has previously logged in already
 app.post("/", async (req, res, next) => {

--- a/project_start/express-api/youtubeSetup.js
+++ b/project_start/express-api/youtubeSetup.js
@@ -1,4 +1,5 @@
-var google = require("googleapis");
+var { google } = require("googleapis");
+
 const youtube = google.youtube({
   version: "v3",
   auth: "AIzaSyCUySF3Hfii_MpUUGHtKOzdI4uVtB51raE",

--- a/project_start/src/components/NewPost/NewPost.jsx
+++ b/project_start/src/components/NewPost/NewPost.jsx
@@ -162,6 +162,13 @@ export default function NewPost({
       songId: songId,
     });
 
+    const youtubeStatistics = await axios.get(
+      `${baseUrl}/youtube/search-list`,
+      {
+        query: selectedSongName,
+      }
+    );
+
     await axios
       .post(`${baseUrl}/post/new-post`, {
         songId: songId,
@@ -172,6 +179,7 @@ export default function NewPost({
         mood: mapMood(mood),
         rating: rating,
         audioFeatures: audioFeatures.data,
+        youtubeStatistics: youtubeStatistics.data,
       })
       .then((song) => {
         axios.post(`${baseUrl}/update-genre`, {


### PR DESCRIPTION
- Installed Google Developer API into project and configured API key 
- Got top search request for query based on song title 
- Incorporate log base 100 of the number of views on a certain song into the song's score which is used in relevance and genre based recommendation

Test Plan

Get proper statistics from YouTube API
<img width="224" alt="image" src="https://user-images.githubusercontent.com/26664975/182498150-544dc1a3-bdaf-4cbc-a5f1-79f7ee5e003b.png">

Score updates as expected (more views = higher initial score)
<img width="319" alt="image" src="https://user-images.githubusercontent.com/26664975/182498188-8626f7e0-6137-4676-9c34-2da2493422bc.png">

Recommendations still load
<img width="570" alt="image" src="https://user-images.githubusercontent.com/26664975/182498258-e9e27b08-90fe-49d4-bed1-ae3185b30785.png">